### PR TITLE
fix: css fix in canvas

### DIFF
--- a/pem-ui/packages/page-designer/src/components/canvas/field-renderer/field-renderer.js
+++ b/pem-ui/packages/page-designer/src/components/canvas/field-renderer/field-renderer.js
@@ -74,18 +74,18 @@ const FieldRenderer = ({
   );
   drag(ref);
   return !previewMode ? (
-    <div ref={isNestedBlock ? ref : null} style={{ opacity }}>
+    <div ref={isNestedBlock ? ref : null} style={{ opacity}}>
       <div
         onClick={(e) => {
           setIsSelected([{ [path]: true }]);
         }}
         className={isSelected[0] !== undefined && isSelected[0][path] ? 'element form-fields-Selected' : 'element'}
-      >
-        <Grid className="custom-field-grid">
+      > 
+        <Grid fullWidth className="custom-field-grid">
           {isNestedBlock && (
             <Column lg={1} className="col-span-margin">
               <span className="drag-icon">
-                <Draggable />
+                <Draggable className='drag-icon'/>
               </span>
             </Column>
           )}
@@ -96,9 +96,12 @@ const FieldRenderer = ({
         </Grid>
         {isNestedBlock && (
           <>
+          <div className="add-row-container">
             <div className="add-row" onClick={(e) => onAddRow(e, path)}>
-              <AddRowIcon />
+                <AddRowIcon />
             </div>
+          </div>
+           
             {isSelected[0] !== undefined && isSelected[0][path] && (
               <div className="action-container">
                 <Grid className="actions-icons">

--- a/pem-ui/packages/page-designer/src/components/canvas/field-renderer/field-renderer.scss
+++ b/pem-ui/packages/page-designer/src/components/canvas/field-renderer/field-renderer.scss
@@ -11,7 +11,7 @@
   border: 1px solid hsl(205, 100%, 50%);
 
   .add-row {
-    display: block;
+    display: flex;
   }
 }
 
@@ -59,8 +59,12 @@
 .add-row {
   display: none;
   position: absolute;
-  left: 33rem;
   bottom: -2rem;
+}
+
+.add-row-container {
+  display: flex;
+  justify-content: center;
 }
 
 .form-fields {
@@ -69,8 +73,8 @@
 
 .canvas-form-fields {
   position: relative;
-  width: 89%;
-  margin-left: 1rem;
+  width: 98%;
+  margin-left: 0.5rem;
 }
 
 .custom-field-grid {
@@ -85,5 +89,9 @@
 }
 
 .col-span-margin {
-  margin-left: -3rem;
+  margin-left: -4rem;
+}
+
+.radio-btn-group {
+  margin-top: 1rem;
 }

--- a/pem-ui/packages/page-designer/src/components/designer/designer.scss
+++ b/pem-ui/packages/page-designer/src/components/designer/designer.scss
@@ -36,6 +36,7 @@
 .actions-container {
   min-height: 3rem;
   padding-right: 1rem;
+  padding-top: 0.5rem;
 }
 
 .layout-container {
@@ -121,20 +122,21 @@
 }
 
 .component-group {
-  border: 1px solid;
-  background-color: #EEEEEE;
+  background-color:#f5f2f2;
   position: absolute;
-  top: 4rem;
+  top: 3rem;
   border-radius: 4px;
+  z-index: 1;
+  box-shadow: 0px 2px 6px 0px #00000040;
 }
 
 .component-group-item {
   cursor: pointer;
-  padding: 0.5rem
+  padding: 0.65rem;
 }
 
 .component-group-item:hover{
-  background-color:#dcdada;
+  background-color:#e9e7e7;
 }
 
 .release-text {

--- a/pem-ui/packages/page-designer/src/components/props-panel/form-props-panel.js
+++ b/pem-ui/packages/page-designer/src/components/props-panel/form-props-panel.js
@@ -27,7 +27,7 @@ export const FormPropsPanel = ({ formFieldProps, onFormPropsChange }) => {
         </TabList>
         <TabPanels>
           <TabPanel>
-            <Grid style={{ marginTop: '1rem', marginLeft: '1rem'  }}>
+            <Grid style={{ marginTop: '1rem', marginLeft: '0.5rem' }}>
               <Column className="props-field" lg={8}>
                 <TextInput
                   id={'form-name'}
@@ -87,7 +87,7 @@ export const FormPropsPanel = ({ formFieldProps, onFormPropsChange }) => {
             </Grid>
           </TabPanel>
           <TabPanel>
-            <Grid style={{ marginTop: '2rem', marginLeft: '1rem' }}>
+            <Grid style={{ marginTop: '2rem', marginLeft: '0.75rem' }}>
               <Column lg={10}>
                 <RadioButtonGroup
                   id={'form-style-opt'}

--- a/pem-ui/packages/page-designer/src/components/props-panel/props-panel.js
+++ b/pem-ui/packages/page-designer/src/components/props-panel/props-panel.js
@@ -441,7 +441,7 @@ export default function PropsPanel({
                                     {/* Mapping */}
                                     {item.type === MAPPING && (
 
-                                      <Column lg={item.size.col}>
+                                      <Column className="mapping-column" lg={item.size.col} >
                                         <TextInput
                                           key={idx}
                                           id={String(idx)}
@@ -455,10 +455,10 @@ export default function PropsPanel({
                                         />
 
                                         <Button
-                                          size="md"
+                                          size="sm"
                                           className="opt-btn context-mapping-btn"
                                           kind="secondary"
-                                          renderIcon={VectorIcon}
+                                          renderIcon={() => <div className='vector-btn'><VectorIcon/></div>}
                                           onClick={() => OpenMappingDialog(selectedFieldProps?.id, key, item.propsName, selectedFieldProps?.currentPathDetail)}
                                         ></Button>
                                       </Column>
@@ -472,7 +472,7 @@ export default function PropsPanel({
                                               key={idx}
                                               size="sm"
                                               id={'toggle-' + key + '-' + String(idx) + '-' + selectedFieldProps?.id}
-                                              className="right-palette-form-item"
+                                              className="right-palette-form-item-toggle"
                                               labelText={item.label}
                                               defaultToggled={Boolean(item.value)}
                                               toggled={Boolean(item.value)}
@@ -493,7 +493,7 @@ export default function PropsPanel({
                                               key={idx}
                                               size="sm"
                                               id={'toggle-' + String(idx) + '-' + selectedFieldProps?.id}
-                                              className="right-palette-form-item "
+                                              className="right-palette-form-item-toggle"
                                               labelText={item.label}
                                               defaultToggled={Boolean(item.value.value)}
                                               toggled={Boolean(item.value.value)}
@@ -528,7 +528,6 @@ export default function PropsPanel({
                                     {/* Radio */}
                                     {item.type === RADIO && (
                                       <Column lg={item.size.col}>
-                                        <div className="right-palette-form-item">
                                           <RadioButtonGroup
                                             key={`radio-group-${item.label}`}
                                             legendText={item.label}
@@ -542,11 +541,10 @@ export default function PropsPanel({
                                             {item?.options.length > 0 &&
                                               item?.options.map((option, idx) =>
                                                 option?.value ? (
-                                                  <RadioButton id={`radio-group-${item.label}-${idx}`} key={idx} labelText={option.label} value={option.value} />
+                                                  <RadioButton className='radio-btn-group' id={`radio-group-${item.label}-${idx}`} key={idx} labelText={option.label} value={option.value} />
                                                 ) : null
                                               )}
                                           </RadioButtonGroup>
-                                        </div>
                                       </Column>
                                     )}
                                     {/* CheckBox */}
@@ -602,7 +600,9 @@ export default function PropsPanel({
                                       <Column lg={item.size.col ? item.size.col : 16}>
                                         <div className="right-palette-form-item">
                                           {file == undefined ? (
-                                            <Button className="attachment-btn" onClick={() => onOpenFiles(key, item.propsName, selectedFieldProps, item.documentCategory)}> Select </Button>
+                                            <div className="attachment-btn">
+                                               <Button size="md" onClick={() => onOpenFiles(key, item.propsName, selectedFieldProps, item.documentCategory)}> Select </Button>
+                                            </div>
                                           ) : (
                                             <FileUploaderItem
                                               errorBody={`500kb max file size. Select a new file and try again.`}
@@ -705,10 +705,10 @@ export default function PropsPanel({
                                                       onChange={(e) => handleRowOpt(index, e.target.value, rowitem.key)}
                                                     />
                                                     <Button
-                                                      size="md"
+                                                      size="sm"
                                                       className="opt-btn context-mapping-btn"
                                                       kind="secondary"
-                                                      renderIcon={VectorIcon}
+                                                      renderIcon={<div className='vector-btn'><VectorIcon/></div>}
                                                       onClick={() =>
                                                         OpenMappingDialog(selectedFieldProps?.id, key, item.propsName, selectedFieldProps?.currentPathDetail, index, rowitem.key)
                                                       }
@@ -773,7 +773,7 @@ export default function PropsPanel({
                           labelText={
                             <>
                               {'Use Value as Label'}
-                              <Tooltip className="min-max-tooltip" align="left" label={'Use value as a label'}>
+                              <Tooltip className="min-max-tooltip" align="top-right" label={'Use value as a label'}>
                                 <Help />
                               </Tooltip>
                             </>
@@ -824,7 +824,7 @@ export default function PropsPanel({
                                     size="md"
                                     className="mapping-button context-mapping-btn"
                                     kind="secondary"
-                                    renderIcon={VectorIcon}
+                                    renderIcon={<div className='vector-btn'><VectorIcon/></div>}
                                     onClick={() => OpenMappingDialog(selectedFieldProps?.id, 'Basic', 'mapping', selectedFieldProps?.currentPathDetail)}
                                   ></Button>
                                 )}
@@ -853,7 +853,7 @@ export default function PropsPanel({
                                       size="md"
                                       className="mapping-button context-mapping-btn"
                                       kind="secondary"
-                                      renderIcon={VectorIcon}
+                                      renderIcon={<div className='vector-btn'><VectorIcon/></div>}
                                       onClick={() => OpenMappingDialog(selectedFieldProps?.id, 'Basic', 'options', selectedFieldProps?.currentPathDetail)}
                                     ></Button>
                                   )}
@@ -874,7 +874,7 @@ export default function PropsPanel({
                                   className={`right-props-icon ${options.length === 1 && 'right-props-margin-icon'}  right-props-icon-background valueasLabel-text-field ${selectedRadioValue === 'static' && !isValueAsLabel && (options.length > 1 ? 'value-label-icon' : 'value-label-opt-icon')}`}
                                 >
                                   <span className="right-props-plus-icon-color" onClick={() => handleAddOption(index)}>
-                                    <CarbonPlus />
+                                    <CarbonPlus className="carbon-plus-btn"/>
                                   </span>
                                 </Column>
                               </>
@@ -896,10 +896,10 @@ export default function PropsPanel({
                               onChange={(e) => handleOptionChange(0, e.target.value, 'value')}
                             />
                             <Button
-                              size="md"
+                              size="sm"
                               className="mapping-button label-mapping-button context-mapping-btn"
                               kind="secondary"
-                              renderIcon={VectorIcon}
+                              renderIcon={()=> <div className='vector-btn'><VectorIcon/></div>}
                               onClick={() => OpenMappingDialog(selectedFieldProps?.id, 'Basic', TABLE_ROWS, selectedFieldProps?.currentPathDetail, 0, 'value')}
                             ></Button>
                           </div>
@@ -919,7 +919,7 @@ export default function PropsPanel({
                                 size="md"
                                 className="mapping-button label-mapping-button context-mapping-btn"
                                 kind="secondary"
-                                renderIcon={VectorIcon}
+                                renderIcon={()=> <div className='vector-btn'><VectorIcon/></div>}
                                 onClick={() => OpenMappingDialog(selectedFieldProps?.id, 'Basic', TABLE_ROWS, selectedFieldProps?.currentPathDetail, 0, 'label')}
                               ></Button>
                             </div>
@@ -939,7 +939,7 @@ export default function PropsPanel({
                               size="md"
                               className="mapping-button label-mapping-button context-mapping-btn"
                               kind="secondary"
-                              renderIcon={VectorIcon}
+                              renderIcon={()=> <div className='vector-btn'><VectorIcon/></div>}
                               onClick={() => OpenMappingDialog(selectedFieldProps?.id, 'Basic', TABLE_ROWS, selectedFieldProps?.currentPathDetail, 1, 'value')}
                             ></Button>
                           </div>
@@ -958,7 +958,7 @@ export default function PropsPanel({
                               size="md"
                               className="mapping-button label-mapping-button context-mapping-btn"
                               kind="secondary"
-                              renderIcon={VectorIcon}
+                              renderIcon={()=> <div className='vector-btn'><VectorIcon/></div>}
                               onClick={() => OpenMappingDialog(selectedFieldProps?.id, 'Basic', TABLE_ROWS, selectedFieldProps?.currentPathDetail, 1, 'label')}
                             ></Button>
                           </div>
@@ -1028,8 +1028,8 @@ export default function PropsPanel({
                                   <>
                                     {advncProps.label}
                                     {advncProps.tooltip && (
-                                      <Tooltip className="min-max-tooltip" align="bottom" label={'It is the ' + advncProps.label + ' of use input'}>
-                                        <Information />
+                                      <Tooltip className="min-max-tooltip" advanceProps align={advncProps.propsName === "min" ? "top-left" : "top-right" } label={'It is the ' + advncProps.label + ' of use input'}>
+                                        <Information/>
                                       </Tooltip>
                                     )}
                                   </>
@@ -1265,7 +1265,7 @@ export default function PropsPanel({
                                   );
                                 }}
                               >
-                                <DatePickerInput id="date-picker-single" labelText={advncProps?.label} placeholder="mm/dd/yyyy" />
+                                <DatePickerInput id="date-picker-single-validation" labelText={advncProps?.label} placeholder="mm/dd/yyyy" />
                               </DatePicker>
                             </Column>
                           )}

--- a/pem-ui/packages/page-designer/src/components/props-panel/props-panel.scss
+++ b/pem-ui/packages/page-designer/src/components/props-panel/props-panel.scss
@@ -5,7 +5,7 @@
   flex: 1;
   overflow-x: hidden;
   overflow-y: scroll;
-  padding: 10px;
+  padding: 8px;
 }
 
 .right-palette-container .tab-panel {
@@ -22,6 +22,7 @@
   // margin-bottom: 16px;
   // max-width: 90% !important;
   display: inline-block;
+  width: 88%;
 }
 
 .mapping-button {
@@ -47,10 +48,11 @@
 // }
 
 .opt-btn {
+  height: 2.55rem !important;
   background-color: #e8e8e8;
   padding-inline-end: unset;
   border-color: #0f62fe;
-  margin-top: 2.5rem;
+  margin-top: 2.46rem;
 }
 
 .opt-btn > svg {
@@ -163,7 +165,7 @@
 .right-props-icon {
   border: 1px solid #0f62fe;
   width: 100%;
-  height: 55%;
+  height: 67%;
   padding-top: 0.4rem;
   padding-left: 0.35rem;
   margin-left: 0.35rem;
@@ -210,6 +212,7 @@
 
 .radio-col-gap {
   margin-left: 0.5rem;
+  width: 98%;
 }
 
 .value-radio-btn-group {
@@ -225,7 +228,7 @@
 }
 
 .label-mapping-button {
-  margin-top: 1.5rem;
+  margin-top: 2.44rem;
 }
 
 .mapping-text-field-dynamic {
@@ -315,4 +318,26 @@
   min-height: 40px;
   height: 41px;
   margin-top: 2.5rem !important;
+}
+
+.radio-btn-group {
+  margin-top: 0.5rem;
+}
+
+.attachment-btn {
+  margin-left: 2.6rem;
+  margin-top: 2.3rem;
+}
+
+.mapping-column {
+  display: flex;
+  width: 96%;
+}
+
+.carbon-plus-btn {
+  margin-left: 0.12rem;
+}
+
+.vector-btn {
+  margin-left: -0.25rem;
 }


### PR DESCRIPTION
- canvas row plus button centralisation
- in properties in mapping button size & alignment issue 
- drag icon alignment
- preview button in form builder 
- cross verify  property aignment 
- after clicking plus icon inside row the dropdown should be aligned acc. to figma 
- the property panel alignment between all components
- dynamic in dropdown row in checkbox
- in Image row for the property the select button is going up when we click on select button
- file download property select button
- on date property in validator the calender is opening in corner screen when we click on min Date & max date text
- make elipse icon in center of button
- the canvas row size fix for the inner row 
- validator max length info alignment 
- orientation alignment
- select type