### PR TITLE
fix: definiton form cancel & exit functionality

### DIFF
--- a/pem-ui/packages/flow-designer/src/components/activity-definition-form/index.js
+++ b/pem-ui/packages/flow-designer/src/components/activity-definition-form/index.js
@@ -8,7 +8,6 @@ import './../block-properties-tray/block-properties-tray.scss';
 
 export default function ActivityDefinitionForm(props) {
   const { readOnly, versionData = [], setShowActivityDefineDrawer, onActivityDetailsSave, activityOperation, activityDefinitionData, onExpand, setNotificationProps } = props;
-
   const [isExpanded, setIsExpanded] = useState(false);
 
   const onExpansionIconClick = (isExpanded) => {
@@ -75,6 +74,7 @@ export default function ActivityDefinitionForm(props) {
         readOnly={readOnly}
         setShowActivityDefineDrawer={setShowActivityDefineDrawer}
         setNotificationProps={setNotificationProps}
+        isExpanded={isExpanded}
       />
     </div>
   );

--- a/pem-ui/packages/flow-designer/src/components/activity-task-definition/activity-task-definition.js
+++ b/pem-ui/packages/flow-designer/src/components/activity-task-definition/activity-task-definition.js
@@ -1,12 +1,12 @@
 /* eslint-disable react/prop-types */
 import React, { useEffect, useState } from 'react';
-import { TextInput, Button, TextArea, Column, Grid } from '@carbon/react';
+import { TextInput, Button, TextArea, Column, Grid, Modal } from '@carbon/react';
 import './activity-task-definition.scss';
 import { VectorIcon } from '../../icons';
 import { ACTIVITY_TASK_SCHEMA } from '../../constants';
 import Shell from '@b2bi/shell';
 
-const ActivityTaskDefinition = ({ id, onSubmitDefinitionForm, setShowActivityDefineDrawer, activityDefinitionData, readOnly, activityOperation }) => {
+const ActivityTaskDefinition = ({ id, onSubmitDefinitionForm, setShowActivityDefineDrawer, activityDefinitionData, readOnly, activityOperation, isExpanded }) => {
   ACTIVITY_TASK_SCHEMA.fields = ACTIVITY_TASK_SCHEMA.fields.map((item) => ({ ...item, isReadOnly: readOnly }));
   const pageUtil = Shell.PageUtil();
   const [formState, setFormState] = useState({
@@ -15,6 +15,16 @@ const ActivityTaskDefinition = ({ id, onSubmitDefinitionForm, setShowActivityDef
     contextData: '{}'
   });
   const [errors, setErrors] = useState({ errors: {} });
+  const [openCancelDialog, setOpenCancelDialog] = useState(false);
+
+  const onCancelDefinitionForm = () => {
+    setOpenCancelDialog(true);
+  };
+
+  const onCloseModel = () => {
+    setOpenCancelDialog(false)
+    setShowActivityDefineDrawer(false)
+  }
 
   useEffect(() => {
     if (activityDefinitionData && activityDefinitionData.definition) {
@@ -148,8 +158,11 @@ const ActivityTaskDefinition = ({ id, onSubmitDefinitionForm, setShowActivityDef
             invalidText={errors.errors.description}
           />
         </Column>
-        <Column className="col-margin" lg={formState.contextData !== '' ? 15 : 16}>
+      </Grid>
+      <Grid >
+        <Column className="col-margin" lg={isExpanded ? 15 : 14}>
           <TextArea
+            className="txt-area"
             id="contextData"
             data-testid="contextData"
             labelText={pageUtil.t('mod-context-data-properties:form.contextData')}
@@ -164,7 +177,7 @@ const ActivityTaskDefinition = ({ id, onSubmitDefinitionForm, setShowActivityDef
           />
         </Column>
         {formState.contextData !== '' && (
-          <Column lg={1} className="context-mapping-button-container">
+          <Column className="context-mapping-button-container">
             <Button
               onClick={() => {
                 validateContextData(formState.contextData);
@@ -180,8 +193,10 @@ const ActivityTaskDefinition = ({ id, onSubmitDefinitionForm, setShowActivityDef
             />
           </Column>
         )}
+      </Grid>
+      <Grid fullWidth className="button-container-container">
         <Column lg={16} className="buttons-containers">
-          <Button onClick={() => setShowActivityDefineDrawer(false)} kind="secondary" data-testid="cancel" name="cancel" type="button" className="button" disabled={readOnly}>
+          <Button onClick={onCancelDefinitionForm} kind="secondary" data-testid="cancel" name="cancel" type="button" className="button" disabled={readOnly}>
             {pageUtil.t('mod-context-data-properties:form.button.cancel')}
           </Button>
           <Button onClick={handleSave} data-testid="save" color="primary" variant="contained" type="button" className="button" disabled={readOnly}>
@@ -189,6 +204,23 @@ const ActivityTaskDefinition = ({ id, onSubmitDefinitionForm, setShowActivityDef
           </Button>
         </Column>
       </Grid>
+      <Modal
+        open={openCancelDialog}
+        onRequestClose={() => setOpenCancelDialog(false)}
+        isFullWidth
+        modalHeading="Confirmation"
+        primaryButtonText="Exit"
+        secondaryButtonText="Cancel"
+        onRequestSubmit={onCloseModel}
+      >
+        <p
+          style={{
+            padding: '0px 0px 1rem 1rem'
+          }}
+        >
+          Your changes are not saved. Do you want to exit without saving changes?{' '}
+        </p>
+      </Modal>
     </form>
   );
 };

--- a/pem-ui/packages/flow-designer/src/components/activity-task-definition/activity-task-definition.scss
+++ b/pem-ui/packages/flow-designer/src/components/activity-task-definition/activity-task-definition.scss
@@ -1,20 +1,9 @@
-.buttons-containers {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  min-height: 48px;
-  margin: 0px;
-  justify-content: flex-end;
-  flex-direction: row;
-  position: absolute;
-  bottom: 0;
-}
-
 .context-mapping-btn {
   background-color: #ffffff;
   height: 2.6rem;
   width: 2.6rem;
-  padding-top: 0.7rem;
+  margin-left: 2rem !important;
+  margin-bottom: 4rem
 }
 
 .attachment-mapping-btn {
@@ -26,8 +15,6 @@
   display: flex;
 }
 
-.context-mapping-button-container {
-  position: relative;
-  top: -20px;
-  margin-top: 5rem;
+.txt-area {
+  margin-left: 1rem;
 }

--- a/pem-ui/packages/flow-designer/src/components/activity-task-definition/activity-task-definition.scss
+++ b/pem-ui/packages/flow-designer/src/components/activity-task-definition/activity-task-definition.scss
@@ -3,7 +3,7 @@
   height: 2.6rem;
   width: 2.6rem;
   margin-left: 2rem !important;
-  margin-bottom: 4rem
+  margin-bottom: 3rem
 }
 
 .attachment-mapping-btn {

--- a/pem-ui/packages/flow-designer/src/components/api-node-definition-form/api-node-definition-form.js
+++ b/pem-ui/packages/flow-designer/src/components/api-node-definition-form/api-node-definition-form.js
@@ -616,6 +616,11 @@ export default function APINodeDefinitionForm({
 
   };
 
+  const onCloseModel = () => {
+    setOpenCancelDialog(false);
+    setOpenPropertiesBlock(false)
+  }
+
   return (
     <div>
       <Tabs onChange={handleTabChange}>
@@ -732,6 +737,7 @@ export default function APINodeDefinitionForm({
         modalHeading="Confirmation"
         primaryButtonText="Exit"
         secondaryButtonText="Cancel"
+        onRequestSubmit={onCloseModel}
       >
         <p
           style={{

--- a/pem-ui/packages/flow-designer/src/components/block-definition-form/block-definition-form.js
+++ b/pem-ui/packages/flow-designer/src/components/block-definition-form/block-definition-form.js
@@ -8,7 +8,7 @@ import { COMPONENT_MAPPER, INITIAL_QUERY, NODE_TYPE, queryValidation } from '../
 import ConditionalBuilder from '../condition-builder';
 import { FormSpy } from '@data-driven-forms/react-form-renderer';
 
-export default function BlockDefinitionForm({ id, selectedNode, selectedTaskNode = null, schema, readOnly, setOpenPropertiesBlock, setNotificationProps, activityDefinitionData }) {
+export default function BlockDefinitionForm({ id, selectedNode, selectedTaskNode = null, schema, readOnly, setOpenPropertiesBlock, setNotificationProps, activityDefinitionData, setShowActivityDefineDrawer}) {
   let newSchema = { ...schema };
   newSchema.fields = newSchema.fields.map((item) => ({ ...item, isReadOnly: readOnly, helperText: readOnly ? '' : item.helperText }));
   const [openCancelDialog, setOpenCancelDialog] = useState(false);
@@ -32,6 +32,12 @@ export default function BlockDefinitionForm({ id, selectedNode, selectedTaskNode
     setOpenCancelDialog(true);
   };
 
+  const onCloseModel = () => {
+    setOpenCancelDialog(false);
+    setOpenPropertiesBlock(false)
+  }
+
+  
   const OnPropertySave = () => {
     queryValidator.current = queryValidation(query, {});
     if (Object.keys(formValidator.current).length === 0 && Object.keys(queryValidator.current).length === 0) {
@@ -152,11 +158,12 @@ export default function BlockDefinitionForm({ id, selectedNode, selectedTaskNode
       </Tabs>
       <Modal
         open={openCancelDialog}
-        onRequestClose={() => setOpenCancelDialog(false)}
+        onRequestClose={()=> setOpenCancelDialog(false)}
         isFullWidth
         modalHeading="Confirmation"
         primaryButtonText="Exit"
         secondaryButtonText="Cancel"
+        onRequestSubmit={onCloseModel}
       >
         <p
           style={{

--- a/pem-ui/packages/flow-designer/src/components/branch-start-properties-tray/branch-start-properties-tray.js
+++ b/pem-ui/packages/flow-designer/src/components/branch-start-properties-tray/branch-start-properties-tray.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Grid, Column, TextInput, Button } from '@carbon/react';
+import { Grid, Column, TextInput, Button, Modal } from '@carbon/react';
 import useTaskStore from '../../store';
 import './branch-start-properties-tray.scss';
 import { TrashCan } from '@carbon/icons-react';
@@ -64,6 +64,8 @@ export default function BranchStartPropertiesTray({
   const [branchNameError, setBranchNameError] = useState(false);
   const [selectedBranchConnector, setSelectedBranchConnector] = useState([]);
   const [showDialogSequence, setShowDialogSequence] = useState(false);
+  const [openCancelDialog, setOpenCancelDialog] = useState(false);
+
   useEffect(() => {
     setBranchName(selectedNode?.data?.editableProps.name ? selectedNode?.data?.editableProps.name : selectedNode?.data.id);
   }, [storeData]);
@@ -160,6 +162,15 @@ export default function BranchStartPropertiesTray({
     }
   };
 
+  const onCancelDefinitionForm = () => {
+    setOpenCancelDialog(true);
+  };
+
+  const onCloseModel = () => {
+    setOpenCancelDialog(false);
+    setOpenPropertiesBlock(false)
+  }
+  
   return (
     <>
       {/* Name input */}
@@ -264,7 +275,7 @@ export default function BranchStartPropertiesTray({
           </Grid>
           <Grid className="button-container-container">
             <Column lg={16} className="buttons-container">
-              <Button data-testid="cancel" name="cancel" kind="secondary" type="button" className="button" onClick={saveBranchData} disabled={readOnly}>
+              <Button data-testid="cancel" name="cancel" kind="secondary" type="button" className="button" onClick={onCancelDefinitionForm} disabled={readOnly}>
                 Cancel
               </Button>
               <Button data-testid="save" color="primary" variant="contained" type="submit" className="button" onClick={saveBranchData} disabled={readOnly}>
@@ -274,6 +285,23 @@ export default function BranchStartPropertiesTray({
           </Grid>
         </>
       )}
+      <Modal
+        open={openCancelDialog}
+        onRequestClose={()=> setOpenCancelDialog(false)}
+        isFullWidth
+        modalHeading="Confirmation"
+        primaryButtonText="Exit"
+        secondaryButtonText="Cancel"
+        onRequestSubmit={onCloseModel}
+      >
+        <p
+          style={{
+            padding: '0px 0px 1rem 1rem'
+          }}
+        >
+          Your changes are not saved. Do you want to exit without saving changes?{' '}
+        </p>
+      </Modal>
     </>
   );
 }

--- a/pem-ui/packages/flow-designer/src/components/branch-start-properties-tray/branch-start-properties-tray.js
+++ b/pem-ui/packages/flow-designer/src/components/branch-start-properties-tray/branch-start-properties-tray.js
@@ -187,7 +187,7 @@ export default function BranchStartPropertiesTray({
             invalidText="Branch Name is required"
           />
         </Column>
-        {/* <Column className="branch-delete" lg={8}>
+        <Column className="branch-delete" lg={8}>
           <span
             onClick={() => {
               deleteNode(selectedNode.id, isDialogFlowActive, selectedTaskNode?.id, true);
@@ -195,7 +195,7 @@ export default function BranchStartPropertiesTray({
           >
             <TrashCan />
           </span>
-        </Column> */}
+        </Column>
       </Grid>
       {/* Conditional Builder and Dialog Sequence */}
       {branchStart && (

--- a/pem-ui/packages/flow-designer/src/components/xslt-node-definition-form/xslt-node-definition-form.js
+++ b/pem-ui/packages/flow-designer/src/components/xslt-node-definition-form/xslt-node-definition-form.js
@@ -219,6 +219,11 @@ export default function XsltNodeDefinitionForm({
     setOpenCancelDialog(true);
   };
 
+  const onCloseModel = () => {
+    setOpenCancelDialog(false);
+    setOpenPropertiesBlock(false)
+  }
+
   return (
     <div>
       <Tabs>
@@ -314,6 +319,7 @@ export default function XsltNodeDefinitionForm({
         modalHeading="Confirmation"
         primaryButtonText="Exit"
         secondaryButtonText="Cancel"
+        onRequestSubmit={onCloseModel}
       >
         <p
           style={{


### PR DESCRIPTION
- CSS issue with save button and text area alignment
-  On click of cancel button for activity definition form, confirmation model should come
-  for all task and nodes after model confirmation side property should be close